### PR TITLE
Fix mIsBeingDragged if condition.

### DIFF
--- a/lib/src/main/java/org/deejdev/twowaynestedscrollview/TwoWayNestedScrollView.java
+++ b/lib/src/main/java/org/deejdev/twowaynestedscrollview/TwoWayNestedScrollView.java
@@ -942,7 +942,7 @@ public class TwoWayNestedScrollView extends FrameLayout implements NestedScrolli
                 if (getChildCount() == 0) {
                     return false;
                 }
-                if ((mIsBeingDragged = !mScroller.isFinished())) {
+                if ((mIsBeingDragged == !mScroller.isFinished())) {
                     final ViewParent parent = getParent();
                     if (parent != null) {
                         parent.requestDisallowInterceptTouchEvent(true);


### PR DESCRIPTION
Using the assignment as condition prevented `TwoWayNestedScrollView` to work properly inside `RecyclerView` as `parent.requestDisallowInterceptTouchEvent(true)` was never reached when user vertically scrolled.

before the fix->
https://github.com/ultimate-deej/TwoWayNestedScrollView/assets/37804517/fa290059-473e-454f-99cb-b8693cd40178

after the fix->
https://github.com/ultimate-deej/TwoWayNestedScrollView/assets/37804517/837878b2-1cad-4b8f-b5c4-0fe7448083b6

